### PR TITLE
Post-training rho calibration via validation grid search

### DIFF
--- a/cvxro/train/settings.py
+++ b/cvxro/train/settings.py
@@ -258,6 +258,11 @@ class TrainerSettings:
         self.target_eta = 0.1
         self.avg_scale = 0
 
+        # --- Rho calibration settings ---
+        self.tune_rho = False               # Enable post-training rho calibration
+        self.tune_rho_n_grid = 30           # Number of grid points
+        self.tune_rho_range = (0.01, 3.0)   # Rho multiplier range (min, max)
+
         # --- AL improvement settings ---
         self.dual_update_strategy = "classic"  # "classic" | "pid"
 

--- a/cvxro/train/trainer.py
+++ b/cvxro/train/trainer.py
@@ -1,3 +1,4 @@
+import copy
 import gc
 from abc import ABC
 
@@ -1695,7 +1696,7 @@ class Trainer:
             return_a_history = a_history[index_chosen] + a_history_s[0]
             return_b_history = b_history[index_chosen] + b_history_s[0]
             return_rho_history = rho_history[index_chosen] + rho_history_s[0]
-            return Result(
+            result = Result(
                 self,
                 self.problem_canon,
                 return_df,
@@ -1711,22 +1712,31 @@ class Trainer:
                 rho_history=return_rho_history,
                 predictor=predictors_s[0],
             )
-        return Result(
-            self,
-            self.problem_canon,
-            df[index_chosen],
-            df_test[index_chosen],
-            df_validate[index_chosen],
-            self.unc_set.a.value,
-            self.unc_set.b.value,
-            return_rho,
-            param_vals[index_chosen][3],
-            var_values[index_chosen],
-            a_history=a_history[index_chosen],
-            b_history=b_history[index_chosen],
-            rho_history=rho_history[index_chosen],
-            predictor=predictors[index_chosen],
-        )
+        else:
+            result = Result(
+                self,
+                self.problem_canon,
+                df[index_chosen],
+                df_test[index_chosen],
+                df_validate[index_chosen],
+                self.unc_set.a.value,
+                self.unc_set.b.value,
+                return_rho,
+                param_vals[index_chosen][3],
+                var_values[index_chosen],
+                a_history=a_history[index_chosen],
+                b_history=b_history[index_chosen],
+                rho_history=rho_history[index_chosen],
+                predictor=predictors[index_chosen],
+            )
+
+        # Post-training rho calibration
+        if self.settings.tune_rho:
+            calibrated_rho = self._tune_rho(result)
+            result._rho = calibrated_rho
+            self._rho_mult_parameter[0].value = calibrated_rho
+
+        return result
 
     def compare_predictors(
             self,
@@ -1753,7 +1763,54 @@ class Trainer:
             validate_dfs.append(result.df_validate)
         return pd.concat(validate_dfs), pd.concat(test_dfs)
 
+    def _tune_rho(self, result):
+        """Post-training rho calibration via grid search on validation data.
 
+        Finds the smallest rho where validation violation probability <= target_eta.
+        Uses compare_predictors to evaluate each candidate rho.
+        """
+        trained_rho = result.rho
+        target_eta = self.settings.target_eta
+        n_grid = self.settings.tune_rho_n_grid
+        lo, hi = self.settings.tune_rho_range
+
+        # Save settings (compare_predictors -> train() overwrites self.settings)
+        saved_settings = self.settings
+
+        # Build log-spaced grid of absolute rho values
+        rho_grid = np.logspace(np.log10(lo), np.log10(hi), n_grid) * trained_rho
+
+        best_rho = trained_rho
+        best_violation = np.inf
+        feasible_found = False
+
+        for rho_val in rho_grid:
+            eval_settings = copy.copy(saved_settings)
+            eval_settings.tune_rho = False  # prevent recursive calibration
+            try:
+                df_valid, _ = self.compare_predictors(
+                    settings=eval_settings,
+                    predictors_list=[result.predictor],
+                    rho_list=[rho_val],
+                )
+                viol = df_valid["Avg_prob_validate"].iloc[0]
+            except Exception:
+                continue
+
+            if viol <= target_eta:
+                if not feasible_found or rho_val < best_rho:
+                    best_rho = rho_val
+                    best_violation = viol
+                    feasible_found = True
+            elif not feasible_found:
+                if viol < best_violation:
+                    best_violation = viol
+                    best_rho = rho_val
+
+        # Restore settings
+        self.settings = saved_settings
+
+        return best_rho
 
     def gen_unique_x(self, x_batch):
         """get unique x's from a list of x parameters."""

--- a/tests/learning/test_al_strategies.py
+++ b/tests/learning/test_al_strategies.py
@@ -235,5 +235,58 @@ class TestStrategyCrossSettings(unittest.TestCase):
         self.assertIsNotNone(result.df)
 
 
+class TestRhoCalibration(unittest.TestCase):
+    """Test post-training rho calibration."""
+
+    def test_tune_rho_setting_defaults(self):
+        """Verify new settings exist with correct defaults."""
+        s = TrainerSettings()
+        self.assertFalse(s.tune_rho)
+        self.assertEqual(s.tune_rho_n_grid, 30)
+        self.assertEqual(s.tune_rho_range, (0.01, 3.0))
+
+    def test_tune_rho_disabled_no_change(self):
+        """tune_rho=False should not alter training behavior."""
+        _, trainer, data = _make_portfolio_problem()
+        settings = _base_settings(data)
+        settings.tune_rho = False
+        result = trainer.train(settings=settings)
+        self.assertIsNotNone(result.df)
+        self.assertGreater(result.rho, 0)
+
+    def test_tune_rho_enabled(self):
+        """tune_rho=True should run and return a valid rho."""
+        _, trainer, data = _make_portfolio_problem()
+        settings = _base_settings(data)
+        settings.tune_rho = True
+        settings.tune_rho_n_grid = 5
+        settings.tune_rho_range = (0.5, 2.0)
+        result = trainer.train(settings=settings)
+        self.assertIsNotNone(result.df)
+        self.assertGreater(result.rho, 0)
+
+    def test_tune_rho_with_pid(self):
+        """Rho calibration should work with PID strategy."""
+        _, trainer, data = _make_portfolio_problem()
+        settings = _base_settings(data)
+        settings.dual_update_strategy = "pid"
+        settings.tune_rho = True
+        settings.tune_rho_n_grid = 5
+        settings.tune_rho_range = (0.5, 2.0)
+        result = trainer.train(settings=settings)
+        self.assertIsNotNone(result.df)
+        self.assertGreater(result.rho, 0)
+
+    def test_tune_rho_preserves_predictor(self):
+        """Predictor should survive rho calibration."""
+        _, trainer, data = _make_portfolio_problem()
+        settings = _base_settings(data)
+        settings.tune_rho = True
+        settings.tune_rho_n_grid = 3
+        settings.tune_rho_range = (0.8, 1.2)
+        result = trainer.train(settings=settings)
+        self.assertIsNotNone(result.predictor)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Merge after #57. After #57 is merged, change target branch from `al-improvements` to `develop`.

Adds automatic post-training rho calibration to reduce conservatism in contextual robust optimization. During contextual training, rho (uncertainty set radius) is fixed at `init_rho` — `_set_train_variables` only optimizes predictor parameters and alpha, not rho. This causes solutions to be overly conservative (e.g., test violation 2-15x below target eta).

The new `_tune_rho()` method runs a log-spaced grid search over rho values on validation data after training, selecting the smallest rho where violation probability ≤ target_eta.

### Changes

- **`cvxro/train/settings.py`**: Add 3 new settings: `tune_rho` (bool), `tune_rho_n_grid` (int), `tune_rho_range` (tuple)
- **`cvxro/train/trainer.py`**: Add `_tune_rho()` method after `compare_predictors`; modify both `train()` return paths to apply calibration when `tune_rho=True`
- **`tests/learning/test_al_strategies.py`**: Add `TestRhoCalibration` class with 5 tests

### Experiment results (from cvxro_experiments#5)

| Problem | init_rho | cal_rho | Test viol (before) | Test viol (after) | Test obj (before) | Test obj (after) | Target |
|---------|----------|---------|-------------------|-------------------|-------------------|-------------------|--------|
| Portfolio | 1.50 | 0.52 | 0.006 | 0.110 | -0.802 | -0.647 | 0.10 |
| Newsvendor | 1.00 | 0.76 | 0.040 | 0.084 | 1.87e-8 | 1.23e-8 | 0.10 |
| Inventory | 1.50 | 0.93 | 0.015 | 0.073 | -381.25 | -395.20 | 0.10 |

## Test plan

- [x] `ruff check .` passes
- [x] 18 tests pass (`pytest tests/learning/test_al_strategies.py -v`), including 5 new rho calibration tests
- [x] All 6 experiment runs complete successfully in cvxro_experiments